### PR TITLE
Bump version and API and allow parallel installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.userprefs
 bin/
 obj/
-dbus-sharp-glib-1.0.pc
+dbus-sharp-glib-2.0.pc
 Makefile
 Makefile.in
 aclocal.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,14 +1,14 @@
 SUBDIRS = src examples
 
 pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = dbus-sharp-glib-1.0.pc
+pkgconfig_DATA = dbus-sharp-glib-2.0.pc
 
 EXTRA_DIST = \
-	dbus-sharp-glib-1.0.pc.in \
+	dbus-sharp-glib-2.0.pc.in \
 	dbus-sharp.snk
 
 DISTCLEANFILES = \
-	dbus-sharp-glib-1.0.pc
+	dbus-sharp-glib-2.0.pc
 
 MAINTAINERCLEANFILES = \
 	INSTALL \

--- a/configure.ac
+++ b/configure.ac
@@ -1,18 +1,16 @@
-AC_INIT(src/GLib.cs)
+m4_define([api_version], [2.0])
+m4_define([lib_version], [0.6.0])
 
-AC_CANONICAL_SYSTEM
 AC_PREREQ(2.13)
 
-API_VERSION=1.0
-#VERSION=$API_VERSION.0
-VERSION=0.5.0
-
-AC_SUBST(API_VERSION)
-AC_SUBST(VERSION)
-
-AM_INIT_AUTOMAKE(dbus-sharp-glib, $VERSION)
+AC_INIT([dbus-sharp-glib], lib_version)
+AC_CONFIG_SRCDIR([src/GLib.cs])
+AM_INIT_AUTOMAKE
 
 AM_MAINTAINER_MODE
+
+AC_SUBST([API_VERSION], [api_version])
+AC_SUBST([VERSION], [lib_version])
 
 AC_PROG_INSTALL
 
@@ -38,7 +36,7 @@ fi
 AC_SUBST(GACUTIL)
 
 DBUS_SHARP_REQUIRED_VERSION=0.7
-PKG_CHECK_MODULES(DBUS_SHARP, dbus-sharp-1.0 >= $DBUS_SHARP_REQUIRED_VERSION)
+PKG_CHECK_MODULES(DBUS_SHARP, dbus-sharp-2.0 >= $DBUS_SHARP_REQUIRED_VERSION)
 AC_SUBST(DBUS_SHARP_LIBS)
 
 #GLIB_REQUIRED_VERSION=2.0
@@ -48,7 +46,7 @@ AC_SUBST(DBUS_SHARP_LIBS)
 
 AC_OUTPUT([
 Makefile
-dbus-sharp-glib-1.0.pc
+dbus-sharp-glib-2.0.pc
 src/AssemblyInfo.cs
 src/Makefile
 examples/Makefile

--- a/dbus-sharp-glib-2.0.pc.in
+++ b/dbus-sharp-glib-2.0.pc.in
@@ -6,5 +6,5 @@ Name: Managed DBus GLib integration
 Description: GLib integration for dbus-sharp, the D-Bus IPC library
 Version: @VERSION@
 URL: http://mono.github.com/dbus-sharp/
-Requires: dbus-sharp-1.0
+Requires: dbus-sharp-2.0
 Libs: -r:${libdir}/mono/@PACKAGE@-@API_VERSION@/dbus-sharp-glib.dll

--- a/src/GLib.cs
+++ b/src/GLib.cs
@@ -5,6 +5,7 @@
 using System;
 using DBus;
 using DBus.GLib;
+using DBus.Protocol;
 using org.freedesktop.DBus;
 
 namespace DBus
@@ -29,7 +30,7 @@ namespace DBus
 		{
 			IOFunc dispatchHandler = delegate (IntPtr source, IOCondition condition, IntPtr data) {
 				if ((condition & IOCondition.Hup) == IOCondition.Hup) {
-					if (Protocol.Verbose)
+					if (ProtocolInformation.Verbose)
 						Console.Error.WriteLine ("Warning: Connection was probably hung up (" + condition + ")");
 
 					//TODO: handle disconnection properly, consider memory management


### PR DESCRIPTION
Fix build against latest dbus-sharp from git master by tracking API
changes.

Although there are no API changes in dbus-sharp-glib itself, it
will only work with the dbus-sharp 2.0 API. So it makes sense to make
dbus-sharp-glib parallel-installable with previous versions. So we do
the necessary changes and rename the pkg-config file.

Also update configure.ac to avoid deprecation warnings with recent
autotools.
