### PR TITLE
Use mcs instead of gmcs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,11 +23,11 @@ AC_SUBST(PKG_CONFIG)
 MONO_REQ_VERSION=1.1.13
 PKG_CHECK_MODULES(MONO, mono >= $MONO_REQ_VERSION)
 
-AC_PATH_PROG(GMCS, mcs, no)
-if test "x$GMCS" = "xno"; then
+AC_PATH_PROG(MCS, mcs, no)
+if test "x$MCS" = "xno"; then
 	AC_MSG_ERROR([You need to install mcs])
 fi
-AC_SUBST(GMCS)
+AC_SUBST(MCS)
 
 AC_PATH_PROG(GACUTIL, gacutil, no)
 if test "x$GACUTIL" = "xno"; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,7 @@ CSFILES = \
 all: $(TARGET)
 
 $(TARGET): $(CSFILES) AssemblyInfo.cs
-	$(GMCS) -out:$@ $(CSFLAGS) $(LIBFLAGS) $^
+	$(MCS) -out:$@ $(CSFLAGS) $(LIBFLAGS) $^
 
 install-data-local:
 	@if test -n '$(TARGET)'; then                       \


### PR DESCRIPTION
These changes didn't get merged somehow previously, so I was keeping my own fork. Hopefully this can be accepted soon.